### PR TITLE
Switch logger filename creation to non-templated format function

### DIFF
--- a/src/util/log.d
+++ b/src/util/log.d
@@ -223,8 +223,9 @@ string[] archiveFiles(size_t n, string path)
 
     auto length = n.to!string.length;
 
+    // FIXME switch back to templated syntax once dlang issue 19252 is fixed
     return n.iota
-        .map!(i => format!"%s-%0*s%s"(path.stripExtension, length, i + 1, path.extension))
+        .map!(i => format("%s-%0*s%s", path.stripExtension, length, i + 1, path.extension))
         .array;
 }
 


### PR DESCRIPTION
This avoids [#19252](https://issues.dlang.org/show_bug.cgi?id=19252) allocating 2GB of RAM per call.